### PR TITLE
Python 3

### DIFF
--- a/python/apriltag.py
+++ b/python/apriltag.py
@@ -442,7 +442,7 @@ def main():
         if have_cv2:
             orig = cv2.imread(filename)
             if len(orig.shape) == 3:
-                gray = cv2.cvtColor(orig, cv2.COLOR_RGB2GRAY)
+                gray = cv2.cvtColor(orig, cv2.COLOR_BGR2GRAY)
             else:
                 gray = orig
         else:
@@ -462,9 +462,9 @@ def main():
             print()
 
         if len(orig.shape) == 3:
-            overlay = orig / 2 + dimg[:, :, None] / 2
+            overlay = orig // 2 + dimg[:, :, None] // 2
         else:
-            overlay = gray / 2 + dimg / 2
+            overlay = gray // 2 + dimg // 2
 
         if have_cv2:
             cv2.imshow('win', overlay)

--- a/python/apriltag.py
+++ b/python/apriltag.py
@@ -146,7 +146,7 @@ tuple class.
         return '\n'.join(rval)
 
     def __str__(self):
-        return self.tostring()
+        return self.tostring().encode('ascii')
 
 ######################################################################
 
@@ -274,7 +274,7 @@ add_arguments; or an instance of the DetectorOptions class.'''
             if not os.path.exists(relpath):
                 raise
             self.libc = ctypes.CDLL(relpath)
-            
+
         # declare return types of libc function
         self._declare_return_types()
 
@@ -365,13 +365,13 @@ image of type numpy.uint8.'''
 
         '''Add a single tag family to this detector.'''
 
-        family = self.libc.apriltag_family_create(name)
+        family = self.libc.apriltag_family_create(name.encode('ascii'))
 
         if family:
             family.contents.border = self.options.border
             self.libc.apriltag_detector_add_family(self.tag_detector, family)
         else:
-            print 'Unrecognized tag family name. Try e.g. tag36h11'
+            print('Unrecognized tag family name. Try e.g. tag36h11')
 
     def _vis_detections(self, shape, detections):
 
@@ -453,13 +453,13 @@ def main():
         detections, dimg = det.detect(gray, return_image=True)
 
         num_detections = len(detections)
-        print 'Detected {} tags.\n'.format(num_detections)
+        print('Detected {} tags.\n'.format(num_detections))
 
         for i, detection in enumerate(detections):
-            print 'Detection {} of {}:'.format(i+1, num_detections)
-            print
-            print detection.tostring(indent=2)
-            print
+            print( 'Detection {} of {}:'.format(i+1, num_detections))
+            print()
+            print( detection.tostring(indent=2))
+            print()
 
         if len(orig.shape) == 3:
             overlay = orig / 2 + dimg[:, :, None] / 2
@@ -477,4 +477,3 @@ def main():
 if __name__ == '__main__':
 
     main()
-

--- a/python/apriltag.py
+++ b/python/apriltag.py
@@ -10,6 +10,8 @@ Original author: Isaac Dulin, Spring 2016
 Updates: Matt Zucker, Fall 2016
 
 """
+from __future__ import division
+from __future__ import print_function
 
 import ctypes
 import collections

--- a/python/camtest.py
+++ b/python/camtest.py
@@ -43,15 +43,15 @@ def main():
         detections, dimg = detector.detect(gray, return_image=True)
 
         num_detections = len(detections)
-        print 'Detected {} tags.\n'.format(num_detections)
+        print('Detected {} tags.\n'.format(num_detections))
 
         for i, detection in enumerate(detections):
-            print 'Detection {} of {}:'.format(i+1, num_detections)
-            print
-            print detection.tostring(indent=2)
-            print
+            print('Detection {} of {}:'.format(i+1, num_detections))
+            print()
+            print(detection.tostring(indent=2))
+            print()
 
-        overlay = frame / 2 + dimg[:, :, None] / 2
+        overlay = frame // 2 + dimg[:, :, None] // 2
 
         cv2.imshow(window, overlay)
         k = cv2.waitKey(1)

--- a/python/camtest.py
+++ b/python/camtest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 '''Demonstrate Python wrapper of C apriltag library by running on camera frames.'''
+from __future__ import division
+from __future__ import print_function
 
 from argparse import ArgumentParser
 import cv2


### PR DESCRIPTION
As described in #4 , the python code wasn't python 3 compatible. 

The three fixes here are:
- print statements, of course
- converting strings to ascii, as expected for the ctypes library
- forcing integer division when creating overlay image

