### PR TITLE
Fixing conflicting types for ‘utime_to_timespec’

### DIFF
--- a/core/common/time_util.h
+++ b/core/common/time_util.h
@@ -32,9 +32,15 @@ either expressed or implied, of the FreeBSD Project.
 #ifndef _TIME_UTIL_H
 #define _TIME_UTIL_H
 
+#if __STDC_VERSION__ >= 199901L
+#define _XOPEN_SOURCE 600
+#else
+#define _XOPEN_SOURCE 500
+#endif /* __STDC_VERSION__ */
+#include <time.h>
+
 #include <stdint.h>
 #include <sys/time.h>
-#include <time.h>
 #include <unistd.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
I was getting this error when trying to build on ubuntu 18.04. Unsure why. This seemed to be the most straight forward solution, something to do with c99 vs posix (found here https://stackoverflow.com/questions/14415465/why-do-i-get-in-my-timespec-array-the-error-array-type-has-incomplete-element-t)